### PR TITLE
Migrating away from Google Code and build fixes

### DIFF
--- a/common/job.go
+++ b/common/job.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"time"
 )
 

--- a/common/queue/queue.go
+++ b/common/queue/queue.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"github.com/pborman/uuid"
-	"code.google.com/p/go-uuid/uuid"
 	"crypto/tls"
 	"encoding/json"
 	"errors"

--- a/common/queue/queue.go
+++ b/common/queue/queue.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"github.com/pborman/uuid"
 	"code.google.com/p/go-uuid/uuid"
 	"crypto/tls"
 	"encoding/json"

--- a/common/resource/basic_failure_test.go
+++ b/common/resource/basic_failure_test.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/pborman/uuid"
 	"github.com/jmmcatee/cracklord/common"
 	"net/rpc"

--- a/common/resource/basic_failure_test.go
+++ b/common/resource/basic_failure_test.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"github.com/jmmcatee/cracklord/common"
 	"net/rpc"
 	"testing"

--- a/common/resource/basic_queue_test.go
+++ b/common/resource/basic_queue_test.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"github.com/jmmcatee/cracklord/common"
 	"log"
 	"net/rpc"

--- a/common/resource/resource.go
+++ b/common/resource/resource.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/jmmcatee/cracklord/common"

--- a/plugins/tools/hashcat/hashcat-tasker.go
+++ b/plugins/tools/hashcat/hashcat-tasker.go
@@ -253,13 +253,13 @@ func newHashcatTask(j common.Job) (common.Tasker, error) {
 			}
 		}
 	}
-	
-	var increment string
+
+	increment := ""
 	incrementKey, ok := h.job.Parameters["increment"]
 	if !ok {
 		log.Debug("No increment flag set.")
 	}else {
-		increment := incrementKey
+		increment = incrementKey
 	}
 	
 
@@ -282,7 +282,7 @@ func newHashcatTask(j common.Job) (common.Tasker, error) {
 		args = append(args, "-1", bruteCharSet)
 		if increment != ""{
 			args = append(args, "--increment", bruteLength)
-		} else args = append(args, bruteLength)
+		} else { args = append(args, bruteLength)}
 	} else {
 		log.WithFields(log.Fields{
 			"ruleFile":     ruleFile,

--- a/plugins/tools/hashcat/hashcat-tasker.go
+++ b/plugins/tools/hashcat/hashcat-tasker.go
@@ -253,7 +253,7 @@ func newHashcatTask(j common.Job) (common.Tasker, error) {
 			}
 		}
 	}
-
+	
 	increment := ""
 	incrementKey, ok := h.job.Parameters["increment"]
 	if !ok {


### PR DESCRIPTION
I tried to build from source this evening, and even on the latest version of Go, I ran into some problems.  d3834bc and 0ea355b fix some warnings with the uuid package.  [GoDoc](https://godoc.org/code.google.com/p/go-uuid/uuid) still points to google code, while some packages survived the migrationt to godoc, according to [this](https://code.google.com/archive/p/go-uuid/) it now belongs [here](https://github.com/pborman/uuid).  Looks like he is a Google employee, so should be legit.

The [ad_auth.go](https://github.com/jmmcatee/cracklord/blob/master/cmd/queued/ad_auth.go#L7) uses [gokerb](https://github.com/jmckaskill/gokerb) which relies on the old google code md4. I sumitted jmckaskill/gokerb/pull/5.  I'm not sure it will get fixed as it hasn't been updated in a while.

79ee137 and 5546c7e address some issues with some code added in #93.  It seems that the compiler [doesn't like](https://golang.org/doc/faq#unused_variables_and_imports) when you have a variable that you declare but don't use.  I think this is the right solution to the problem, but I'm totally new to Go so let me know if there is a better way to do it.