### PR TITLE
Fix for error "No url found for submodule path"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,7 @@
+[submodule "goschemaform"]
+	path = vendor/github.com/jmmcatee/goschemaform
+	url = git://github.com/jmmcatee/goschemaform
+
+[submodule "testify"]
+	path = vendor/github.com/stretchr/testify
+	url = git://github.com/stretchr/testify


### PR DESCRIPTION
Current version of cracklord in repo misses .gitmodules file. This block recommended build through "go get" command with following errors:

```
$  go get github.com/jmmcatee/cracklord
# cd PATH/src/github.com/jmmcatee/cracklord; git submodule update --init --recursive
fatal: No url found for submodule path 'vendor/github.com/jmmcatee/goschemaform' in .gitmodules
package github.com/jmmcatee/cracklord: exit status 128
```

Pull request fixes issue for me.