### PR TITLE
queued: Fix CertFile typo

### DIFF
--- a/cmd/queued/queued.go
+++ b/cmd/queued/queued.go
@@ -93,7 +93,7 @@ func main() {
 
 	CertPath, ok := genConf["CertFile"]
 	if !ok {
-		log.Error("The KeyFile directive was not included in the 'General' section of the configuration file.")
+		log.Error("The CertFile directive was not included in the 'General' section of the configuration file.")
 		log.Error("See https://github.com/jmmcatee/cracklord/src/wiki/Configuration-Files.")
 	}
 	CertPath = common.StripQuotes(CertPath)

--- a/cmd/resourced/resourced.go
+++ b/cmd/resourced/resourced.go
@@ -72,7 +72,7 @@ func main() {
 
 	resCertPath, ok := resConf["CertFile"]
 	if !ok {
-		log.Error("The KeyFile directive was not included in the 'General' section of the configuration file.")
+		log.Error("The CertFile directive was not included in the 'General' section of the configuration file.")
 		log.Error("See https://github.com/jmmcatee/cracklord/src/wiki/Configuration-Files.")
 	}
 	resCertPath = common.StripQuotes(resCertPath)


### PR DESCRIPTION
I found a tiny typo in the error messages.